### PR TITLE
Fix shebang

### DIFF
--- a/gpr.js
+++ b/gpr.js
@@ -1,4 +1,4 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 /**
  *`git pull` from the repo and branch that a PR originates from.
  * Copyright 2016 Matthew Brookes. License: MIT


### PR DESCRIPTION
On my machine (and probably on those of many other people), node is not located in `/usr/local/bin/node` but somewhere else (especially when using tools like `nvm`).

This fixes the shebang as described [here](https://stackoverflow.com/a/24253067).